### PR TITLE
Statistics out

### DIFF
--- a/src/app/pages/home.page/home.page.component.html
+++ b/src/app/pages/home.page/home.page.component.html
@@ -159,13 +159,10 @@
                                     }}</span>
                                 </div>
                                 <div>
-                                    <strong>Rows: </strong>
+                                    <strong>Processed: </strong>
                                     <span>{{
                                         dataForFile?.statistics?.rows_read
-                                    }}</span>
-                                </div>
-                                <div>
-                                    <strong>Size: </strong>
+                                    }} rows, </span>
                                     <span>
                                         {{
                                             bytesToSize(

--- a/src/app/pages/home.page/home.page.component.html
+++ b/src/app/pages/home.page/home.page.component.html
@@ -173,19 +173,19 @@
                                             )
                                         }}
                                     </span>
-                                    
+
                                     <span>
                                         ({{
                                             timeShorter(
-                                              (dataForFile?.statistics?.elapsed || 0) / ( parseFloat(dataForFile?.statistics?.elapsed) || 0.001 )
+                                              (dataForFile?.statistics?.elapsed || 0) / ( parseFloat(dataForFile?.statistics?.elapsed || 0) || 0.001 )
                                             )
                                         }} rows/s. {{
                                             bytesToSize(
-                                                (dataForFile?.statistics?.bytes_read || 0) / ( parseFloat(dataForFile?.statistics?.elapsed) || 0.001 )
+                                                (dataForFile?.statistics?.bytes_read || 0) / ( parseFloat(dataForFile?.statistics?.elapsed || 0) || 0.001 )
                                             )
                                         }}/s.)
                                     </span>
-                                    
+
                                 </div>
                             </div>
                             <custom-ag-grid

--- a/src/app/pages/home.page/home.page.component.html
+++ b/src/app/pages/home.page/home.page.component.html
@@ -150,17 +150,19 @@
                         <ng-template #hasData>
                             <div class="short-stat">
                                 <div>
-                                    <strong>Elapsed: </strong>
+                                    <span>{{
+                                        timeShorter(
+                                            dataForFile?.rows ||
+                                                0
+                                        )
+                                    }} rows in set. Elapsed </span>
                                     <span>{{
                                         timeShorter(
                                             dataForFile?.statistics?.elapsed ||
                                                 0
                                         )
-                                    }}</span>
-                                </div>
-                                <div>
-                                    <strong>Processed: </strong>
-                                    <span>{{
+                                    }}. </span>
+                                    <span>Processed {{
                                         dataForFile?.statistics?.rows_read
                                     }} rows, </span>
                                     <span>

--- a/src/app/pages/home.page/home.page.component.html
+++ b/src/app/pages/home.page/home.page.component.html
@@ -173,6 +173,19 @@
                                             )
                                         }}
                                     </span>
+                                    
+                                    <span>
+                                        ({{
+                                            timeShorter(
+                                              (dataForFile?.statistics?.elapsed || 0) / ( parseFloat(dataForFile?.statistics?.elapsed) || 0.001 )
+                                            )
+                                        }} rows/s. {{
+                                            bytesToSize(
+                                                (dataForFile?.statistics?.bytes_read || 0) / ( parseFloat(dataForFile?.statistics?.elapsed) || 0.001 )
+                                            )
+                                        }}/s.)
+                                    </span>
+                                    
                                 </div>
                             </div>
                             <custom-ag-grid

--- a/src/app/pages/home.page/home.page.component.ts
+++ b/src/app/pages/home.page/home.page.component.ts
@@ -40,6 +40,7 @@ export class HomePageComponent implements OnInit {
     pageSize: number = 50;
     isPaginator: boolean = true;
     currentRow: Row = new Map();
+    parseFloat = parseFloat;
     constructor(
         private apiService: ApiService,
         private docsService: DocsService,


### PR DESCRIPTION
Should return a response similar to clickhouse-client, ie:
> 50 rows in set. Elapsed: 0.025 sec. Processed 5.07 thousand rows, 806.31 KB (203.49 thousand rows/s., 32.37 MB/s.)